### PR TITLE
fix: :bug: When single speaker, the transcript wasn't segmentating

### DIFF
--- a/app/[id]/TranscriptViewer.tsx
+++ b/app/[id]/TranscriptViewer.tsx
@@ -95,7 +95,7 @@ const getSegmentsBySentences = (
   } = options;
 
   const result: TranscriptionSegment<number>[][] = [];
-  let currentNumOfSentences = numOfSentences;
+  let remainingSentencesInGroup = numOfSentences;
   let currentSegment: TranscriptionSegment<number>[] = [];
 
   // Filter out empty segments and trim text
@@ -145,17 +145,17 @@ const getSegmentsBySentences = (
 
     // Check for sentence-ending punctuation
     if (isSentenceEnd(processedSeg.text)) {
-      currentNumOfSentences--;
+      remainingSentencesInGroup--;
     }
 
     // Finalize group when sentence or fallback limit is met
     if (
-      currentNumOfSentences <= 0 ||
+      remainingSentencesInGroup <= 0 ||
       currentSegment.length >= maxSegmentsPerGroup
     ) {
       result.push(currentSegment);
       currentSegment = [];
-      currentNumOfSentences = numOfSentences;
+      remainingSentencesInGroup = numOfSentences;
     }
   }
 

--- a/app/[id]/TranscriptViewer.tsx
+++ b/app/[id]/TranscriptViewer.tsx
@@ -67,18 +67,15 @@ const getSegmentsBySentences = (
   );
 
   for (const seg of nonEmptySegments) {
-    // Skip empty segments
-    if (seg.text.trim().length === 0) continue;
-
     const processedSeg: TranscriptionSegment<number> = removeSpeakers
       ? { ...seg, speaker: "" }
       : seg;
 
     // Check for long segments and split if needed
-    const wordCount = processedSeg.text.split(" ").length;
+    const wordCount = processedSeg.text.trim().split(/\s+/).filter(Boolean).length;
     if (wordCount > maxWordsPerSegment) {
       // Split segment into smaller chunks by words
-      const words = processedSeg.text.split(" ");
+      const words = processedSeg.text.trim().split(/\s+/).filter(Boolean);
       const splitSegments: TranscriptionSegment<number>[] = words.map(
         (word) => ({
           ...processedSeg,
@@ -149,9 +146,6 @@ const getSegmentsBySpeakersAndSentences = (
   );
 
   for (const seg of nonEmptySegments) {
-    // Skip empty segments
-    if (seg.text.trim().length === 0) continue;
-
     if (currentSpeaker.length === 0) {
       currentSpeaker.push({ ...seg, text: seg.text.trim() });
       continue;


### PR DESCRIPTION
Fix transcript segmentation: implement sentence-based grouping

- Add `getSegmentsBySentences` to group segments by sentence-ending punctuation
- Add `getSegmentsBySpeakersAndSentences` to group by speaker, then apply sentence segmentation
- Fix single-speaker transcripts not being divided into timestamped segments
- Ensure multi-speaker transcripts are properly grouped by speaker and segmented by sentences