### PR TITLE
fix: 🐛  Fix download PDF, to be a Open in new tab

### DIFF
--- a/app/[id]/PdfViewerNew.tsx
+++ b/app/[id]/PdfViewerNew.tsx
@@ -28,9 +28,10 @@ const A4_ASPECT_RATIO = Math.sqrt(2);
 
 type Props = {
   pdfFile: PdfFile;
+  shareId: string;
 };
 
-export default function PdfViewerNew({ pdfFile }: Props) {
+export default function PdfViewerNew({ pdfFile, shareId }: Props) {
   const [numPages, setNumPages] = useState<number>(0);
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [scale, setScale] = useState<number>(1.0);
@@ -85,8 +86,16 @@ export default function PdfViewerNew({ pdfFile }: Props) {
     setScale((prev) => Math.max(prev - SCALE_STEP, MIN_SCALE));
   };
 
-  const handleOpenInNewTab = () => {
-    window.open(pdfFile.pdfPath, '_blank', 'noopener,noreferrer');
+  const handleOpenInNewTab = async () => {
+    try {
+      const res = await fetch(`/api/pdf-download?shareId=${encodeURIComponent(shareId)}`);
+      if (!res.ok) throw new Error('Failed to load PDF');
+      const blob = await res.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      window.open(blobUrl, '_blank', 'noopener,noreferrer');
+    } catch (e) {
+      console.error('Download PDF error:', e);
+    }
   };
 
   useEffect(() => {

--- a/app/[id]/Tabs.tsx
+++ b/app/[id]/Tabs.tsx
@@ -49,7 +49,7 @@ export default function Tabs({ summary, transcript, shareId, pdfFile }: Props) {
           <TranscriptViewer transcription={transcript} />
         ) : null;
       case "pdf":
-        return pdfFile ? <PdfViewerNew pdfFile={pdfFile} /> : null;
+        return pdfFile ? <PdfViewerNew pdfFile={pdfFile} shareId={shareId} /> : null;
       default:
         return null;
     }

--- a/app/api/pdf-download/route.ts
+++ b/app/api/pdf-download/route.ts
@@ -20,6 +20,11 @@ export async function GET(req: NextRequest) {
     const db = admin.firestore();
 
     const publicLinkDoc = await db.collection("public_links").doc(shareId).get();
+
+    if (!publicLinkDoc.exists) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    
     const userId = publicLinkDoc.data()?.userId;
     const recordingId = publicLinkDoc.data()?.recordingId;
 

--- a/app/api/pdf-download/route.ts
+++ b/app/api/pdf-download/route.ts
@@ -1,0 +1,97 @@
+import admin from "@/app/lib/firebase/firebase-admin";
+import { PdfFile } from "@/app/lib/firebase/recording/@types";
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * PDF download by shareId only. Resolves the PDF path server-side so
+ * userId/recordingId and Firebase URLs are never exposed to the client.
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const shareId = req.nextUrl.searchParams.get("shareId");
+
+    if (!shareId) {
+      return NextResponse.json(
+        { error: "Missing shareId parameter" },
+        { status: 400 }
+      );
+    }
+
+    const db = admin.firestore();
+
+    const publicLinkDoc = await db.collection("public_links").doc(shareId).get();
+    const userId = publicLinkDoc.data()?.userId;
+    const recordingId = publicLinkDoc.data()?.recordingId;
+
+    if (!userId || !recordingId) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const recordingDoc = await db
+      .collection("users")
+      .doc(userId)
+      .collection("recordings")
+      .doc(recordingId)
+      .get();
+
+    if (!recordingDoc.exists) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const pdfFile = recordingDoc.data()?.pdfFile as PdfFile | undefined;
+    if (!pdfFile?.pdfPath) {
+      return NextResponse.json(
+        { error: "No PDF for this recording" },
+        { status: 404 }
+      );
+    }
+
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(pdfFile.pdfPath);
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid PDF source" },
+        { status: 400 }
+      );
+    }
+
+    if (parsedUrl.hostname !== "firebasestorage.googleapis.com") {
+      return NextResponse.json(
+        { error: "Invalid PDF source" },
+        { status: 400 }
+      );
+    }
+
+    const response = await fetch(pdfFile.pdfPath, {
+      headers: { Accept: "application/pdf" },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: "Failed to fetch PDF" },
+        { status: response.status }
+      );
+    }
+
+    const pdfBuffer = await response.arrayBuffer();
+
+    return new NextResponse(pdfBuffer, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": "inline; filename=document.pdf",
+        "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      },
+    });
+  } catch (error) {
+    console.error("Error in PDF download API:", error);
+    return NextResponse.json(
+      {
+        error: "Internal server error",
+        details: error instanceof Error ? error.message : "Unknown",
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Changed download PDF, to open it in a new tab, where the url is a new id (it doesn't show the user the recording id, nor the user id)